### PR TITLE
Use a simpler version of the iterator

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,8 +245,8 @@ to the block and requiring you to write the comparison logic, just passes one
 element to the block:
 
 ```rb
-users.sort_by do |user1|
-  user1[:name]
+users.sort_by do |user|
+  user[:name]
 end
 # => [{:name=>"Cara", :phone=>"555-555-5556"}, {:name=>"Duane", :phone=>"555-555-5555"}, {:name=>...
 ```


### PR DESCRIPTION
This pull request proposes a change to the last example of the Enumerables lesson to use an easier to understand block argument. Since there is only one argument, there is no need to add a numberic identifer to the end.